### PR TITLE
KTA-1 Fix Embedly error, Vimeo error, SimpleJson error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 dist/
 magicembed.egg-info/
+build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django Magic Embed
 What is it?
 ------------
 
-Magic Embed is an easy and simple Django template tag and tool to embed 
+Magic Embed is an easy and simple Django template tag and tool to embed
 video and get thumbnails from video providers.
 
 Demo
@@ -28,17 +28,17 @@ You can download it from PyPI here
 How to install it?
 -------------------
 
-If you have a requeriments list add this to your requeriments 
+If you have a requeriments list add this to your requeriments
 
 1. <code>magicembed==(version)</code>
 
 2. <code>pip install -r requirements.txt</code>
 
+3. <code>add magicembed to **INSTALLED_APPS**</code>
+
 Or if you use setup.py
 
-1. add magicembed to **INSTALLED_APPS**
-
-2. run <code>python setup.py install</code>
+1. run <code>python setup.py install</code>
 
 How to use
 ---------------
@@ -47,7 +47,7 @@ First add this in the template to load the template tags
 
 <code>{% load magicembed_tags %}</code>
 
-Now if you need to embed a video, add this template tag to video url 
+Now if you need to embed a video, add this template tag to video url
 field
 
 <code>{{ video|magicembed:"width x height" }}</code>
@@ -68,3 +68,4 @@ How to contrib
 Licence
 --------------
 Licensed under [MIT](http://opensource.org/licenses/mit-license.php)
+

--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ Screenshots
 Downloading
 ---------------
 
-You can download it from PyPI here
-	[PyPI-Magic Embed](https://pypi.python.org/pypi/magicembed/0.2)
+You can download it from [PyPI](https://pypi.python.org/pypi/magicembed/)
+
+Embedly API key
+------------------
+
+If you want to use [Embedly](http://embed.ly/) please create a new
+account and [generate the key](https://app.embed.ly/signup)
+
+When you have the API key, add this in your settings.py:
+
+    EMBEDLY_KEY='YourAwesomeAPIKey'
 
 How to install it?
 -------------------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPI version](https://badge.fury.io/py/magicembed.svg)](http://badge.fury.io/py/magicembed)
+
 Django Magic Embed
 ==================
 

--- a/magicembed/providers.py
+++ b/magicembed/providers.py
@@ -1,7 +1,11 @@
-from urlparse import parse_qs
+# -*- coding: utf-8 -*-
+import json
 import re
 import urllib
-from django.utils import simplejson
+
+from urlparse import parse_qs
+
+from django.conf import settings
 
 class Provider(object):
 
@@ -37,8 +41,8 @@ class Vimeo(Provider):
 
     def __init__(self, url, size=(640, 480)):
         super(Vimeo, self).__init__(url, size)
-        pattern = re.compile('http://(?:www\.)?vimeo\.com/([0-9]{1,12})')
-        self.video_id = pattern.match(url).groups()[0]
+        pattern = re.compile('(http|https)://(?:www\.)?vimeo\.com/([0-9]{1,12})')
+        self.video_id = pattern.match(url).groups()[1]
         self.api_url = 'http://vimeo.com/api/v2/video/%s.json' % self.video_id
 
     def render_video(self):
@@ -47,14 +51,22 @@ class Vimeo(Provider):
                 self.size[1], self.video_id)
 
     def render_thumbnail(self, link_to="#"):
-        api_response = simplejson.loads(urllib.urlopen(self.api_url).read())
+        api_response = json.loads(urllib.urlopen(self.api_url).read())
         return api_response[0]['thumbnail_medium']
 
 class Embedly(Provider):
 
     def __init__(self, url, size=(640, 480)):
         super(Embedly, self).__init__(url, size)
-        self.api_url = 'http://api.embed.ly/1/oembed?url=%s&maxwidth=%s&format=json' % (url, size[0])
+        key = getattr(settings, "EMBEDLY_KEY", None)
+        if key != None:
+            try:
+                self.api_url = 'http://api.embed.ly/1/oembed?key=%s&url=%s&maxwidth=%s&format=json' % (key, url, size[0])
+            except IOError:
+                raise IOError("Please set the Embedly api key correctly")
+        else:
+            raise ValueError("If you want to use this please set the Embedly api key")
+
 
     def render_video(self):
         return self._call_api()['html']
@@ -63,7 +75,7 @@ class Embedly(Provider):
         return self._call_api()['thumbnail_url']
 
     def _call_api(self):
-        data = simplejson.loads(urllib.urlopen(self.api_url).read())
+        data = json.loads(urllib.urlopen(self.api_url).read())
         return data
 
 def get_provider(url, size=None):

--- a/magicembed/providers.py
+++ b/magicembed/providers.py
@@ -60,10 +60,7 @@ class Embedly(Provider):
         super(Embedly, self).__init__(url, size)
         key = getattr(settings, "EMBEDLY_KEY", None)
         if key != None:
-            try:
-                self.api_url = 'http://api.embed.ly/1/oembed?key=%s&url=%s&maxwidth=%s&format=json' % (key, url, size[0])
-            except IOError:
-                raise IOError("Please set the Embedly api key correctly")
+            self.api_url = 'http://api.embed.ly/1/oembed?key=%s&url=%s&maxwidth=%s&format=json' % (key, url, size[0])
         else:
             raise ValueError("If you want to use this please set the Embedly api key")
 
@@ -75,7 +72,10 @@ class Embedly(Provider):
         return self._call_api()['thumbnail_url']
 
     def _call_api(self):
-        data = json.loads(urllib.urlopen(self.api_url).read())
+        try:
+            data = json.loads(urllib.urlopen(self.api_url).read())
+        except IOError:
+            raise IOError("Please set the Embedly api key correctly")
         return data
 
 def get_provider(url, size=None):

--- a/magicembed/templatetags/magicembed_tags.py
+++ b/magicembed/templatetags/magicembed_tags.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
 from django import template
-from magicembed.providers import get_provider
 from django.utils.safestring import mark_safe
+
+from magicembed.providers import get_provider
 
 register = template.Library()
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
 
 setup(
     name = "magicembed",
-    version = "0.3",
+    version = "1.0.0",
     url = "http://github.com/kronoscode/django-magicembed",
     license = 'MIT',
     description = 'Django template filter utils to render videos an thumbnails.',


### PR DESCRIPTION
This PR fix this errors:

    Embedly missing API key.
    Vimeo https support.
    Use python json instead django simplejson.
    Readme.md typo fix.

It's now in 1.0.0 version please create a new github release and upload this to PyPI.

~~Note: Please add PyPI Badge to the readme.md file, read more [here.](https://badge.fury.io/for/py/magicembed)~~ DONE :smile: 