### PR TITLE
docs: Fix simple typo, ussage -> usage

### DIFF
--- a/magicembed/templatetags/magicembed_tags.py
+++ b/magicembed/templatetags/magicembed_tags.py
@@ -10,7 +10,7 @@ register = template.Library()
 @register.filter(is_safe=True)
 def magicembed(value, arg=None):
     '''value is the url and arg the size tuple
-    ussage: {% http://myurl.com/|magicembed:"640x480" %}'''
+    usage: {% http://myurl.com/|magicembed:"640x480" %}'''
     arg = [int(item) for item in arg.split('x')]
     provider = get_provider(value, arg)
 
@@ -20,6 +20,6 @@ def magicembed(value, arg=None):
 @register.filter
 def magicthumbnail(value):
     '''value is the url and arg the link_to another url
-    ussage: {% http://myurl.com/|magicthumbnail: '/some/url' %}'''
+    usage: {% http://myurl.com/|magicthumbnail: '/some/url' %}'''
     provider = get_provider(value)
     return provider.render_thumbnail()


### PR DESCRIPTION
There is a small typo in magicembed/templatetags/magicembed_tags.py.

Should read `usage` rather than `ussage`.

