### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To get the latest commit from GitHub
 pip install -e git+git://github.com/kronoscode/django-magicembed.git#egg=magicembed
 ```
 
-If you have a requeriments list add this to your requeriments
+If you have a requirements list add this to your requirements
 
 1. <code>magicembed==(version)</code>
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -334,7 +334,7 @@ epub_copyright = copyright
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/magicembed/providers.py
+++ b/magicembed/providers.py
@@ -81,7 +81,7 @@ class Embedly(Provider):
 
 
 def get_provider(url, size=None):
-    '''returns a provider instance acording to the url'''
+    '''returns a provider instance according to the url'''
     provider_domain = dict(youtube=Youtube, vimeo=Vimeo)
     for domain, provider in provider_domain.items():
         if domain in url:

--- a/magicembed/tests/runtests.py
+++ b/magicembed/tests/runtests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 This script is a trick to setup a fake Django environment, since this reusable
-app will be developed and tested outside any specifiv Django project.
+app will be developed and tested outside any specific Django project.
 
 Via ``settings.configure`` you will be able to set all necessary settings
 for your app and run the tests as if you were calling ``./manage.py test``.

--- a/magicembed/tests/south_settings.py
+++ b/magicembed/tests/south_settings.py
@@ -3,7 +3,7 @@ These settings are used by the ``manage.py`` command.
 
 With normal tests we want to use the fastest possible way which is an
 in-memory sqlite database but if you want to create South migrations you
-need a persistant database.
+need a persistent database.
 
 Unfortunately there seems to be an issue with either South or syncdb so that
 defining two routers ("default" and "south") does not work.


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/source/conf.py
- magicembed/providers.py
- magicembed/tests/runtests.py
- magicembed/tests/south_settings.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `specific` rather than `specifiv`.
- Should read `requirements` rather than `requeriments`.
- Should read `persistent` rather than `persistant`.
- Should read `according` rather than `acording`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md